### PR TITLE
Stop potentially forwarding stack-traces from aiia-api

### DIFF
--- a/Web/Controllers/InboundPaymentController.cs
+++ b/Web/Controllers/InboundPaymentController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Aiia.Sample.Controllers;
 
@@ -19,11 +20,13 @@ public class InboundPaymentController : Controller
 {
     private readonly IAiiaService _aiiaService;
     private readonly IWebHostEnvironment _environment;
+    private readonly ILogger<InboundPaymentController> _logger;
 
-    public InboundPaymentController(IAiiaService aiiaService, IWebHostEnvironment environment)
+    public InboundPaymentController(IAiiaService aiiaService, IWebHostEnvironment environment, ILogger<InboundPaymentController> logger)
     {
         _aiiaService = aiiaService;
         _environment = environment;
+        _logger = logger;
     }
 
     [HttpGet("create")]
@@ -61,7 +64,9 @@ public class InboundPaymentController : Controller
         }
         catch (AiiaClientException e)
         {
-            result.ErrorDescription = e.Message;
+            _logger.LogWarning(e, "Something went wrong calling aiia-api");
+
+            result.ErrorDescription = "Something went wrong calling aiia-api";
         }
 
         return Ok(result);

--- a/Web/Controllers/OutboundPaymentController.cs
+++ b/Web/Controllers/OutboundPaymentController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Aiia.Sample.Controllers;
 
@@ -19,6 +20,7 @@ public class OutboundPaymentController : Controller
 {
     private readonly IAiiaService _aiiaService;
     private readonly IWebHostEnvironment _environment;
+    private readonly ILogger<OutboundPaymentController> _logger;
 
     public OutboundPaymentController(IAiiaService aiiaService, IWebHostEnvironment environment)
     {
@@ -61,7 +63,9 @@ public class OutboundPaymentController : Controller
         }
         catch (AiiaClientException e)
         {
-            result.ErrorDescription = e.Message;
+            _logger.LogWarning(e, "Something went wrong calling aiia-api");
+
+            result.ErrorDescription = "Something went wrong calling aiia-api";
         }
 
         return Ok(result);
@@ -102,7 +106,9 @@ public class OutboundPaymentController : Controller
         }
         catch (AiiaClientException e)
         {
-            result.ErrorDescription = e.Message;
+            _logger.LogWarning(e, "Something went wrong calling aiia-api");
+
+            result.ErrorDescription = "Something went wrong calling aiia-api";
         }
 
         return Ok(result);


### PR DESCRIPTION
During pen-testing it was discovered that sometimes errors that are a bit too concrete are forwarded from aiia-api. https://dev.azure.com/spiir/Delivery/_sprints/taskboard/squad-exp-tooling/Delivery/2022/Q4/2022-11?workitem=20673

This PR fixes the above.