### PR TITLE
Removed server header from all http responses

### DIFF
--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -9,11 +9,17 @@ public class Program
 {
     public static IHostBuilder CreateHostBuilder(string[] args)
     {
-        return Host.CreateDefaultBuilder(args).ConfigureWebHostDefaults(options =>
-        {
-            options.UseStartup<Startup>().UseKeyVault()
-                .UseSerilogElasticSearchIngest();
-        });
+        return Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(builder =>
+            {
+                builder.UseKestrel(options =>
+                    {
+                        options.AddServerHeader = false;
+                    })
+                    .UseStartup<Startup>()
+                    .UseKeyVault()
+                    .UseSerilogElasticSearchIngest();
+            });
     }
 
     public static async Task Main(string[] args)


### PR DESCRIPTION
It is a problem that we're displaying we're running on an IIS - this PR makes that no more.

Work item:
https://dev.azure.com/spiir/Delivery/_sprints/taskboard/squad-exp-tooling/Delivery/2022/Q4/2022-11?workitem=20659