### PR TITLE
Made all http responses come back with a Cache-Control: no-store,no-cache header

### DIFF
--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -123,7 +123,8 @@ public class Startup
             {
                 options.Filters.Add(new ResponseCacheAttribute()
                 {
-                    NoStore = true
+                    NoStore = true,
+                    Location = ResponseCacheLocation.None
                 });
             }).AddNewtonsoftJson();
     }

--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -117,7 +118,14 @@ public class Startup
         services.AddHttpClient<IAiiaHttpClient, AiiaHttpClient>();
         services.AddSingleton<AiiaApi, AiiaApi>();
         services.AddRazorPages().AddNewtonsoftJson();
-        services.AddControllers().AddNewtonsoftJson();
+        services.AddControllers()
+            .AddMvcOptions(options =>
+            {
+                options.Filters.Add(new ResponseCacheAttribute()
+                {
+                    NoStore = true
+                });
+            }).AddNewtonsoftJson();
     }
 
     private static void UpdateDatabase(IApplicationBuilder app)


### PR DESCRIPTION
Our pentesters think it's a problem that we dont tell browsers to not cache http-responses. This PR fixes that.

I found the solution here:
https://learn.microsoft.com/en-us/aspnet/core/performance/caching/response?view=aspnetcore-6.0#nostore-and-locationnone

Work item:
https://dev.azure.com/spiir/Delivery/_sprints/taskboard/squad-exp-tooling/Delivery/2022/Q4/2022-11?workitem=20663