### PR TITLE
HTTP Security headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ app\.db
 
 global.json
 *.db
+*.db-shm
+*.db-wal
+


### PR DESCRIPTION
Bump HSTS length to 1 year

Remove duplicated `UseStaticFiles`

Move `UseRouting` below `UseStaticFiles` (middleware ordering now follows the standard recommended way)

Add "HTTP Security" headers